### PR TITLE
Refine battle controls

### DIFF
--- a/src/common/components/Roadmap.module.scss
+++ b/src/common/components/Roadmap.module.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @import '../styles/variables.scss';
 @import '../styles/mixins.scss';
 
@@ -44,7 +45,7 @@
     margin: 0.5rem;
     padding: 0.5rem;
     border-radius: 0.5rem;
-    background-color: transparentize($color-primary, 0.7);
+    background-color: color.adjust($color-primary, $alpha: -0.7);
 
     .dateLabel {
         font-size: 12px;

--- a/src/views/battle/BattleCharacterComponent.module.scss
+++ b/src/views/battle/BattleCharacterComponent.module.scss
@@ -39,6 +39,10 @@
     @include insetShadow($color-error);
 }
 
+.targetDefaultActive {
+    @include insetShadow($color-unique, 25px);
+}
+
 .characterDead {
     opacity: 0.5;
 

--- a/src/views/battle/BattleCharacterComponent.tsx
+++ b/src/views/battle/BattleCharacterComponent.tsx
@@ -17,12 +17,14 @@ export const BattleCharacterComponent = ({
     character,
     isSelected,
     isTargeted,
+    isDefaultTargeted,
     animatedSkill,
     onClick,
 }: {
     character: BattleCharacter;
     isSelected: boolean;
     isTargeted: boolean;
+    isDefaultTargeted?: boolean;
     animatedSkill: BattleMoveResult | undefined;
     onClick: () => void;
 }) => {
@@ -41,6 +43,7 @@ export const BattleCharacterComponent = ({
         ${style.characterItem} 
         ${character.isControlled ? style.characterAlly : ''}
         ${isTargeted ? style.targetActive : ''} 
+        ${isDefaultTargeted ? style.targetDefaultActive : ''} 
         ${isSelected ? style.characterActive : ''} 
         ${!character.isAlive ? style.characterDead : ''}
         ${animating && (character.isControlled ? style.allyAttacking : style.enemyAttacking)}`;
@@ -95,7 +98,7 @@ export const BattleCharacterComponent = ({
                     <div className={style.logItem}>
                         <p>{animatedSkill.skillLabel}</p>
                         {animatedSkill.statusLogs.map((statusLog) => (
-                            <p key={`${character.id}-${statusLog.label}`} className={style.logItemStatus}>
+                            <p key={generateRandomId()} className={style.logItemStatus}>
                                 -{statusLog.value} ({statusLog.label})
                             </p>
                         ))}
@@ -109,8 +112,8 @@ export const BattleCharacterComponent = ({
                             style={{ animationDelay: `${hitIndex / 2}s` }}>
                             <b className={`${hit.value >= 0 ? 'error' : 'success'}`}>
                                 {formatNumber(Math.round(Math.abs(hit.value)))}
-                                {hit.effectLogs.map((effectLog, effectLogIndex) => (
-                                    <p key={`el-${effectLogIndex}`} className={style.effectLogItem}>
+                                {hit.effectLogs.map((effectLog) => (
+                                    <p key={generateRandomId()} className={style.effectLogItem}>
                                         {effectLog}
                                     </p>
                                 ))}
@@ -165,11 +168,11 @@ const BattleCharacterStatus = ({ statuses }: { statuses: BattleStatus[] }) => {
     return (
         <div className={style.statusWrapper}>
             <hr />
-            {statuses.map((status, statusIndex) => (
-                <div key={`status-${statusIndex}`}>
+            {statuses.map((status) => (
+                <div key={generateRandomId()}>
                     {statusModifiers.map(({ key, label }) =>
                         status[key] ? (
-                            <p key={key}>
+                            <p key={generateRandomId()}>
                                 {typeof label === 'string' ? label : label(+status[key])} ({status.duration}{' '}
                                 turns)
                             </p>


### PR DESCRIPTION
- add default target as first alive enemy
- use base class damaging skill as default command against default target
- ability to select skill without specifying target
- ability to select default target
- ability to cancel selection with escape/backspace

---
**For later**
- add dead target switching (backend)
- refactor component with own zustand store for simpler splitting